### PR TITLE
If ip6 but no gw6 is provided, fall back to ra

### DIFF
--- a/src/PVE/LXC/Setup/Base.pm
+++ b/src/PVE/LXC/Setup/Base.pm
@@ -291,6 +291,9 @@ DATA
 	    } elsif ($ip ne 'manual') {
 		$has_ipv6 = 1;
 		$data .= "Address = $ip\n";
+        if (!defined(my $gw = $d->{gw6})) {
+            $accept_ra = 'true';
+        }
 	    }
 	}
 	if (defined(my $gw = $d->{gw6})) {


### PR DESCRIPTION
**Current behavior and problem:** 
IPv6 router advertisements are only evaluated, if the PVE configuration is set to SLAAC. It is not possible to set a fixed (static) IPv6 address, but let the system discover the address of the router.

**Change:**
Since the gateway address is already optional, this patch changes the following:
If a static IPv6 address is specified, but no gateway address is given, enable router discovery via router advertisement.
If both are specified, router advertisement stays disabled.

**PS:** This is my first patch to this project. I couldn’t find a contributor documentation, so I am not sure what your procedure for patches is. Please let me know if you need additional input.

**PPS:**
Since the indentation of the original code was off, I have tried to match it as good as possible.
