### PR TITLE
Update Debian.pm for first point release of Trixie

### DIFF
--- a/src/PVE/LXC/Setup/Debian.pm
+++ b/src/PVE/LXC/Setup/Debian.pm
@@ -36,7 +36,7 @@ sub new {
 
     $version = $1;
 
-    die "unsupported debian version '$version'\n" if !($version >= 4 && $version <= 13);
+    die "unsupported debian version '$version'\n" if !($version >= 4 && $version <= 14);
 
     my $self = { conf => $conf, rootdir => $rootdir, version => $version };
 


### PR DESCRIPTION
https://www.debian.org/News/2025/20250906

Debian 13.1 is released.

Although Promox isnt  officially compatible yet, it prevents containers to start if they were upgraded internally.

Alternatively you could try 13.99 ?